### PR TITLE
Fix Alsace holiday coverage

### DIFF
--- a/dayoff/countries/fr.py
+++ b/dayoff/countries/fr.py
@@ -106,7 +106,7 @@ class FranceHolidays:
                     self.calculate_easter_monday(easter_day),
                     self.calculate_ascension(easter_day),
                     self.calculate_pentecost(easter_day),]
-        if self.department in ["57", "67"]:
+        if self.department in ["57", "67", "68"]:
             holidays.append(Holiday(name=HolidayName.SAINT_ETIENNE, date=date(self.year, 12, 26), type=HolidayType.PUBLIC))
             holidays.append(
                 Holiday(name=HolidayName.VENDREDI_SAINT, date=self.calculate_friday_before_easter(easter_day).date, type=HolidayType.PUBLIC)

--- a/tests/test_france_holidays.py
+++ b/tests/test_france_holidays.py
@@ -69,3 +69,25 @@ class TestAssumptionFranceHolidays(unittest.TestCase):
             date=date(2000, 6, 1),
             type=HolidayType.PUBLIC,
         ))
+
+
+class TestAlsaceMoselleAdditionalHolidays(unittest.TestCase):
+
+    def test_department_68_includes_good_friday_and_st_etienne(self):
+        holidays = FranceHolidays(2023, "68").get_holidays()
+        self.assertIn(
+            Holiday(
+                name=HolidayName.VENDREDI_SAINT,
+                date=date(2023, 4, 7),
+                type=HolidayType.PUBLIC,
+            ),
+            holidays,
+        )
+        self.assertIn(
+            Holiday(
+                name=HolidayName.SAINT_ETIENNE,
+                date=date(2023, 12, 26),
+                type=HolidayType.PUBLIC,
+            ),
+            holidays,
+        )


### PR DESCRIPTION
## Summary
- update holiday rules for Alsace‐Moselle departments
- test that department 68 gets Good Friday and Saint‑Etienne holidays

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443f523c8c832e812515daaee6bccb