### PR TITLE
Fix Friday before Easter object

### DIFF
--- a/dayoff/countries/fr.py
+++ b/dayoff/countries/fr.py
@@ -108,9 +108,7 @@ class FranceHolidays:
                     self.calculate_pentecost(easter_day),]
         if self.department in ["57", "67", "68"]:
             holidays.append(Holiday(name=HolidayName.SAINT_ETIENNE, date=date(self.year, 12, 26), type=HolidayType.PUBLIC))
-            holidays.append(
-                Holiday(name=HolidayName.VENDREDI_SAINT, date=self.calculate_friday_before_easter(easter_day).date, type=HolidayType.PUBLIC)
-            )
+            holidays.append(self.calculate_friday_before_easter(easter_day))
         if self.department in ["971", "972", "973", "974", "976", "977", "978"]:
             holidays.append(self.map_abolition_slavery())
         return holidays

--- a/tests/test_france_holidays.py
+++ b/tests/test_france_holidays.py
@@ -104,6 +104,12 @@ class TestFridayBeforeEasterFranceHolidays(unittest.TestCase):
                 type=HolidayType.PUBLIC,
             ),
         )
+    def test_get_holidays_contains_friday_before_easter(self):
+        fh = FranceHolidays(2023, "67")
+        easter_day = fh.calculate_easter()
+        expected = fh.calculate_friday_before_easter(easter_day)
+        self.assertIn(expected, fh.get_holidays())
+
 
 class TestPentecostFranceHolidays(unittest.TestCase):
     def test_pentecost_2023(self):
@@ -153,3 +159,7 @@ class TestFranceHolidaysList(unittest.TestCase):
             Holiday(name=HolidayName.VENDREDI_SAINT, date=date(2023, 4, 7), type=HolidayType.PUBLIC),
         ]
         self.assertEqual(fh.get_holidays(), expected)
+
+
+
+


### PR DESCRIPTION
## Summary
- append Friday before Easter holiday object directly in France holidays
- test Friday before Easter helper
- test inclusion of Friday before Easter in Alsace Moselle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455bfdf58c832e9ebfcea38da53d42