### PR TITLE
Add multi-country holiday support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Dayoff
+
+Example usage of the package providing holiday calendars for multiple European countries.
+
+```python
+from dayoff import get_holidays, CountryCode
+
+holidays_fr = get_holidays(2024, CountryCode.FR, department="75")
+holidays_de = get_holidays(2024, CountryCode.DE)
+```
+
+`get_holidays` returns a list of `Holiday` objects for the requested country and year.

--- a/dayoff/__init__.py
+++ b/dayoff/__init__.py
@@ -1,0 +1,14 @@
+"""Public API for dayoff package."""
+
+from .countries import (
+    CountryCode,
+    CountryHolidaysFactory,
+)
+
+
+def get_holidays(year: int, country: CountryCode, **kwargs):
+    """Return list of :class:`Holiday` objects for given country and year."""
+    provider = CountryHolidaysFactory.create(country, year, **kwargs)
+    return provider.get_holidays()
+
+__all__ = ["CountryCode", "get_holidays"]

--- a/dayoff/countries/__init__.py
+++ b/dayoff/countries/__init__.py
@@ -1,0 +1,34 @@
+from enum import Enum
+
+from .fr import FranceHolidays
+from .de import GermanyHolidays
+from .es import SpainHolidays
+from .it import ItalyHolidays
+
+class CountryCode(Enum):
+    FR = "FR"
+    DE = "DE"
+    ES = "ES"
+    IT = "IT"
+
+
+class CountryHolidaysFactory:
+    """Return holiday provider classes based on country code."""
+
+    _providers = {
+        CountryCode.FR: FranceHolidays,
+        CountryCode.DE: GermanyHolidays,
+        CountryCode.ES: SpainHolidays,
+        CountryCode.IT: ItalyHolidays,
+    }
+
+    @classmethod
+    def register(cls, code: CountryCode, provider):
+        cls._providers[code] = provider
+
+    @classmethod
+    def create(cls, code: CountryCode, year: int, **kwargs):
+        provider_cls = cls._providers.get(code)
+        if provider_cls is None:
+            raise ValueError(f"Unsupported country: {code}")
+        return provider_cls(year, **kwargs)

--- a/dayoff/countries/de.py
+++ b/dayoff/countries/de.py
@@ -1,0 +1,44 @@
+from datetime import date, timedelta
+
+from dayoff.domain.models import Holiday
+from dayoff.domain.value_objects import HolidayType, HolidayName
+
+
+class GermanyHolidays:
+    def __init__(self, year: int):
+        self.year = year
+
+    def calculate_easter(self) -> date:
+        n = self.year % 19
+        c = self.year // 100
+        u = self.year % 100
+        s = c // 4
+        t = c % 4
+        p = (c + 8) // 25
+        q = (c - p + 1) // 3
+        e = (19 * n + c - s - q + 15) % 30
+        b = u // 4
+        d = u % 4
+        L = (2 * t + 2 * b - e - d + 32) % 7
+        h = (n + 11 * e + 22 * L) // 451
+        m = (e + L - 7 * h + 114) // 31
+        j = (e + L - 7 * h + 114) % 31
+        return date(self.year, m, j + 1)
+
+    @staticmethod
+    def calculate_easter_monday(easter_day: date) -> Holiday:
+        return Holiday(
+            name=HolidayName.EASTER_MONDAY,
+            date=easter_day + timedelta(days=1),
+            type=HolidayType.PUBLIC,
+        )
+
+    def get_holidays(self) -> list[Holiday]:
+        easter = self.calculate_easter()
+        return [
+            Holiday(name=HolidayName.NEW_YEAR, date=date(self.year, 1, 1), type=HolidayType.PUBLIC),
+            Holiday(name=HolidayName.LABOR_DAY, date=date(self.year, 5, 1), type=HolidayType.PUBLIC),
+            Holiday(name=HolidayName.NATIONAL_DAY, date=date(self.year, 10, 3), type=HolidayType.PUBLIC),
+            Holiday(name=HolidayName.CHRISTMAS, date=date(self.year, 12, 25), type=HolidayType.PUBLIC),
+            self.calculate_easter_monday(easter),
+        ]

--- a/dayoff/countries/es.py
+++ b/dayoff/countries/es.py
@@ -1,0 +1,44 @@
+from datetime import date, timedelta
+
+from dayoff.domain.models import Holiday
+from dayoff.domain.value_objects import HolidayType, HolidayName
+
+
+class SpainHolidays:
+    def __init__(self, year: int):
+        self.year = year
+
+    def calculate_easter(self) -> date:
+        n = self.year % 19
+        c = self.year // 100
+        u = self.year % 100
+        s = c // 4
+        t = c % 4
+        p = (c + 8) // 25
+        q = (c - p + 1) // 3
+        e = (19 * n + c - s - q + 15) % 30
+        b = u // 4
+        d = u % 4
+        L = (2 * t + 2 * b - e - d + 32) % 7
+        h = (n + 11 * e + 22 * L) // 451
+        m = (e + L - 7 * h + 114) // 31
+        j = (e + L - 7 * h + 114) % 31
+        return date(self.year, m, j + 1)
+
+    @staticmethod
+    def calculate_easter_monday(easter_day: date) -> Holiday:
+        return Holiday(
+            name=HolidayName.EASTER_MONDAY,
+            date=easter_day + timedelta(days=1),
+            type=HolidayType.PUBLIC,
+        )
+
+    def get_holidays(self) -> list[Holiday]:
+        easter = self.calculate_easter()
+        return [
+            Holiday(name=HolidayName.NEW_YEAR, date=date(self.year, 1, 1), type=HolidayType.PUBLIC),
+            Holiday(name=HolidayName.LABOR_DAY, date=date(self.year, 5, 1), type=HolidayType.PUBLIC),
+            Holiday(name=HolidayName.NATIONAL_DAY, date=date(self.year, 10, 12), type=HolidayType.PUBLIC),
+            Holiday(name=HolidayName.CHRISTMAS, date=date(self.year, 12, 25), type=HolidayType.PUBLIC),
+            self.calculate_easter_monday(easter),
+        ]

--- a/dayoff/countries/it.py
+++ b/dayoff/countries/it.py
@@ -1,0 +1,44 @@
+from datetime import date, timedelta
+
+from dayoff.domain.models import Holiday
+from dayoff.domain.value_objects import HolidayType, HolidayName
+
+
+class ItalyHolidays:
+    def __init__(self, year: int):
+        self.year = year
+
+    def calculate_easter(self) -> date:
+        n = self.year % 19
+        c = self.year // 100
+        u = self.year % 100
+        s = c // 4
+        t = c % 4
+        p = (c + 8) // 25
+        q = (c - p + 1) // 3
+        e = (19 * n + c - s - q + 15) % 30
+        b = u // 4
+        d = u % 4
+        L = (2 * t + 2 * b - e - d + 32) % 7
+        h = (n + 11 * e + 22 * L) // 451
+        m = (e + L - 7 * h + 114) // 31
+        j = (e + L - 7 * h + 114) % 31
+        return date(self.year, m, j + 1)
+
+    @staticmethod
+    def calculate_easter_monday(easter_day: date) -> Holiday:
+        return Holiday(
+            name=HolidayName.EASTER_MONDAY,
+            date=easter_day + timedelta(days=1),
+            type=HolidayType.PUBLIC,
+        )
+
+    def get_holidays(self) -> list[Holiday]:
+        easter = self.calculate_easter()
+        return [
+            Holiday(name=HolidayName.NEW_YEAR, date=date(self.year, 1, 1), type=HolidayType.PUBLIC),
+            Holiday(name=HolidayName.LABOR_DAY, date=date(self.year, 5, 1), type=HolidayType.PUBLIC),
+            Holiday(name=HolidayName.NATIONAL_DAY, date=date(self.year, 6, 2), type=HolidayType.PUBLIC),
+            Holiday(name=HolidayName.CHRISTMAS, date=date(self.year, 12, 25), type=HolidayType.PUBLIC),
+            self.calculate_easter_monday(easter),
+        ]

--- a/tests/test_country_factory.py
+++ b/tests/test_country_factory.py
@@ -1,0 +1,29 @@
+import unittest
+from datetime import date
+
+from dayoff import get_holidays, CountryCode
+from dayoff.countries import CountryHolidaysFactory, GermanyHolidays, SpainHolidays
+
+
+class TestCountryHolidaysFactory(unittest.TestCase):
+    def test_create_germany(self):
+        provider = CountryHolidaysFactory.create(CountryCode.DE, 2024)
+        self.assertIsInstance(provider, GermanyHolidays)
+
+    def test_create_spain(self):
+        provider = CountryHolidaysFactory.create(CountryCode.ES, 2024)
+        self.assertIsInstance(provider, SpainHolidays)
+
+
+class TestGetHolidays(unittest.TestCase):
+    def test_germany_new_year(self):
+        holidays = get_holidays(2024, CountryCode.DE)
+        self.assertIn(date(2024, 1, 1), [h.date for h in holidays])
+
+    def test_spain_national_day(self):
+        holidays = get_holidays(2024, CountryCode.ES)
+        self.assertIn(date(2024, 10, 12), [h.date for h in holidays])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose a simple API in `dayoff` to fetch holidays
- register new `CountryCode` enum and `CountryHolidaysFactory`
- add holiday providers for Germany, Spain and Italy
- support `get_holidays` helper for different countries
- test new factory and helper
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455d065dcc832e807a5d079dc154e9